### PR TITLE
Add warning for --with-dtrace support for python

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -17,13 +17,13 @@
 
 # Python Interpreter Requirements
 The only runtime requirement is a Python interpreter that was built with --with-dtrace (USDT probes).<br>
-You can check if your current interpreter supported by running `readelf` on your python interpreter:
+You can check if your current interpreter supported by running this command:
 ```python
-readelf -n Python-3.10.0/python | grep -i function__entry
+python -m sysconfig | grep WITH_DTRACE
 ```
-You should be able to see the following output:
+This configuration option should have the value "1" (and not "0"!):
 ```
-    Name: function__entry
+	WITH_DTRACE = "1"
 ```
 If your current interpreter is not supported (empty output):
 - Using `pip`

--- a/secimport/cli.py
+++ b/secimport/cli.py
@@ -6,6 +6,7 @@ import stat
 import fire
 import sys
 import yaml
+import subprocess
 import secimport
 from secimport.backends.common.utils import SECIMPORT_ROOT
 
@@ -203,6 +204,10 @@ class SecImportCLI:
             python_interpreter (str, optional): The path of the python executable interpreter to trace. Defaults to sys.executable.
             trace_log_file (str, optional): The log file to write the trace into. Defaults to "trace.log".
         """
+        with_dtrace = subprocess.check_output([python_interpreter, '-c', 'import sysconfig; print(sysconfig.get_config_var("WITH_DTRACE"))'], encoding='utf-8')
+        if with_dtrace.strip() != "1":
+            colored_print(COLORS.FAIL, f"\nIt seems that {python_interpreter} was compiled without --with-dtrace=1. secimport will probably not work properly!\n")
+
         if entrypoint:
             # entrypoint_cmd = str(Path(entrypoint).absolute())
             entrypoint_cmd = f'bash -c "{python_interpreter} {entrypoint}"'


### PR DESCRIPTION
Adds a check using the sysconfig module and prints a warning if the python interpreter was not compiled with --with-dtrace