### PR TITLE
Make trace.bt support any path to the python interpreter

### DIFF
--- a/secimport/cli.py
+++ b/secimport/cli.py
@@ -214,6 +214,7 @@ class SecImportCLI:
             f"{entrypoint_cmd}",
             "-o",
             f"{trace_log_file}",
+            f"{python_interpreter}",
         ]
         colored_print(COLORS.HEADER, "\nTracing using ", cmd)
         colored_print(
@@ -237,12 +238,16 @@ class SecImportCLI:
             trace_log_file (str): The output file to write the trace into.
         """
         assert isinstance(pid, int), f"pid must be an int, got: {pid}"
+
+        python_interpreter = (Path('/proc') / str(pid) / 'exe').resolve()
+
         cmd = [
             str(SECIMPORT_ROOT) + "/profiles/trace.bt",
             "-p",
             f"{pid}",
             "-o",
             f"{trace_log_file}",
+            f"{python_interpreter}"
         ]
         colored_print(COLORS.HEADER, "\nTRACING PID:")
         colored_print(COLORS.OKBLUE, pid)

--- a/secimport/profiles/trace.bt
+++ b/secimport/profiles/trace.bt
@@ -4,7 +4,7 @@
 // It can be attached to a running process using -p or can be used to trace a python shell interactively.
 //
 // Usage:
-// ./trace.bt -c Python-3.10.0/python
+// ./trace.bt Python-3.10.0/python -c Python-3.10.0/python
 
 BEGIN {
     // Mapping all syscalls both ways, based on https://github.com/iovisor/bpftrace/blob/2c7a7a598dbe1aa790db2dfe2db242aa69137d5b/tools/syscount.bt
@@ -688,7 +688,7 @@ BEGIN {
     printf("Tracing Modules - Exit gracefully with Ctrl+D\n")
 }
 
-usdt:/workspace/Python-3.10.0/python:function__entry {
+usdt:$1:function__entry {
         @["depth"]++;
         @entrypoints[str(arg0)] = @["depth"];
         @globals["previous_module"] = @globals["current_module"];
@@ -698,7 +698,7 @@ usdt:/workspace/Python-3.10.0/python:function__entry {
         // printf("%s, %s, depth=%d\n", str(arg0), str(arg1), @["depth"]) ;
 }
 
-usdt:/workspace/Python-3.10.0/python:function__return {
+usdt:$1:function__return {
         @["depth"]--;
 }
 


### PR DESCRIPTION
Before the path to the python interpreter was hard-coded into `trace.bt`. With this MR you must pass the path to the python interpreter as an argument to trace.bt (e.g. `trace.bt /usr/bin/python3`), so you can trace any python executable.