### PR TITLE
feat: Support stapsdt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ secimport = 'secimport.cli:main'
 [tool.poetry.dependencies]
 python = "^3.8"
 PyYAML = "^6.0"
+stapsdt = "^0.1.1"
 typer = ">=0.15.1,<0.21.0"
 
 [tool.poetry.dev-dependencies]

--- a/secimport/backends/common/utils.py
+++ b/secimport/backends/common/utils.py
@@ -1,4 +1,5 @@
 import os
+import sysconfig
 from sys import platform
 from pathlib import Path
 from typing import List
@@ -220,9 +221,12 @@ def build_module_sandbox_from_yaml_template(
         print(f"The profile does not contain any modules: {template_path}")
         return
 
+    has_static_dtrace = sysconfig.get_config_var("WITH_DTRACE") == 1
+    interpreter_path = PYTHON_EXECUTABLE if has_static_dtrace else "*:python"
+
     script_template = script_template.replace("###SYSCALL_FILTER###", syscalls_filter)
     script_template = script_template.replace(
-        "###INTERPRETER_PATH###", PYTHON_EXECUTABLE
+        "###INTERPRETER_PATH###", interpreter_path
     )
     probes_code = ("\n" * 2).join(parsed_probes)
     script_template = script_template.replace(

--- a/secimport/cli.py
+++ b/secimport/cli.py
@@ -194,10 +194,12 @@ class SecImportCLI:
         with_dtrace = subprocess.check_output(
             [python_interpreter, "-c", 'import sysconfig; print(sysconfig.get_config_var("WITH_DTRACE"))'],
             encoding="utf-8",
-        )
-        if with_dtrace.strip() != "1":
+        ).strip()
+        use_stapsdt_wrapper = False
+        if with_dtrace != "1":
             import importlib.util
             if importlib.util.find_spec("stapsdt") is not None:
+                use_stapsdt_wrapper = True
                 colored_print(
                     COLORS.OKBLUE,
                     f"\n[!] {python_interpreter} was compiled without --with-dtrace=1.\n"
@@ -214,7 +216,40 @@ class SecImportCLI:
                     "2. Install 'stapsdt' python package: pip install stapsdt\n",
                 )
 
-        if entrypoint:
+        if use_stapsdt_wrapper:
+            from secimport.backends.common.utils import BASE_DIR_NAME
+            if not BASE_DIR_NAME.exists():
+                BASE_DIR_NAME.mkdir(parents=True, exist_ok=True)
+
+            helper_path = BASE_DIR_NAME / "trace_helper.py"
+            # Prepare the logic to run the script if entrypoint is provided
+            run_logic = f"import runpy; runpy.run_path('{entrypoint}', run_name='__main__')" if entrypoint else ""
+
+            shim_code = f"""
+import sys
+import stapsdt
+
+p = stapsdt.Provider("python")
+# https://docs.python.org/3/howto/instrumentation.html#available-static-markers
+e_p = p.add_probe("function__entry", stapsdt.ArgTypes.uint64, stapsdt.ArgTypes.uint64, stapsdt.ArgTypes.int32)
+r_p = p.add_probe("function__return", stapsdt.ArgTypes.uint64, stapsdt.ArgTypes.uint64, stapsdt.ArgTypes.int32)
+p.load()
+def t(f, e, a):
+    if e == "call":
+        # Using local variables to ensure string stability for bpftrace
+        e_p.fire(f.f_code.co_filename, f.f_code.co_name, f.f_lineno)
+    elif e == "return":
+        r_p.fire(f.f_code.co_filename, f.f_code.co_name, f.f_lineno)
+    return t
+sys.setprofile(t)
+{run_logic}
+"""
+            with open(helper_path, "w") as f:
+                f.write(shim_code)
+
+            interactive_flag = "-i" if not entrypoint else ""
+            entrypoint_cmd = f"{python_interpreter} {interactive_flag} {helper_path}"
+        elif entrypoint:
             entrypoint_cmd = f'bash -c "{python_interpreter} {entrypoint}"'
         else:
             entrypoint_cmd = python_interpreter
@@ -227,9 +262,16 @@ class SecImportCLI:
             trace_log_file,
             python_interpreter,
         ]
+        if os.geteuid() != 0:
+            cmd.insert(0, "sudo")
+
         colored_print(COLORS.HEADER, "\nTracing using ", cmd)
         colored_print(COLORS.BOLD, "Press CTRL+D or CTRL+C to stop the trace gracefully.\n")
-        os.system(" ".join(cmd))
+
+        try:
+            subprocess.run(cmd)
+        except KeyboardInterrupt:
+            pass
         colored_print(
             COLORS.BOLD,
             "The trace log is at",
@@ -259,10 +301,16 @@ class SecImportCLI:
             trace_log_file,
             f"{python_interpreter}",
         ]
+        if os.geteuid() != 0:
+            cmd.insert(0, "sudo")
+
         colored_print(COLORS.HEADER, "\nTRACING PID:")
         colored_print(COLORS.OKBLUE, pid)
         input("\t\t\tPress CTRL+D/CTRL+C to stop the trace;")
-        os.system(" ".join(cmd))
+        try:
+            subprocess.run(cmd)
+        except KeyboardInterrupt:
+            pass
         colored_print(COLORS.ENDC)
 
     @staticmethod
@@ -322,6 +370,9 @@ class SecImportCLI:
                 "The sandbox was not found. Try calling 'secimport trace/trace_pid' and then 'secimport build'."
             )
         sandbox_startup_cmd = [f"{sandbox_executable}", "--unsafe"]
+        if os.geteuid() != 0:
+            sandbox_startup_cmd.insert(0, "sudo")
+
         if pid is not None:
             sandbox_startup_cmd += [f"-p {pid}"]
         elif python_interpreter is not None:
@@ -349,7 +400,10 @@ class SecImportCLI:
             sandbox_startup_cmd.append("KILL")
 
         colored_print(COLORS.HEADER, "RUNNING SANDBOX...", sandbox_startup_cmd)
-        os.system(" ".join(sandbox_startup_cmd))
+        try:
+            subprocess.run(sandbox_startup_cmd)
+        except KeyboardInterrupt:
+            pass
         colored_print(
             COLORS.BOLD,
             "SANDBOX EXITED;",

--- a/secimport/cli.py
+++ b/secimport/cli.py
@@ -255,6 +255,7 @@ sys.setprofile(t)
             entrypoint_cmd = python_interpreter
 
         cmd = [
+            "bpftrace",
             f"{SECIMPORT_ROOT}/profiles/trace.bt",
             "-c",
             entrypoint_cmd,
@@ -369,7 +370,7 @@ sys.setprofile(t)
             raise FileNotFoundError(
                 "The sandbox was not found. Try calling 'secimport trace/trace_pid' and then 'secimport build'."
             )
-        sandbox_startup_cmd = [f"{sandbox_executable}", "--unsafe"]
+        sandbox_startup_cmd = ["bpftrace", f"{sandbox_executable}", "--unsafe"]
         if os.geteuid() != 0:
             sandbox_startup_cmd.insert(0, "sudo")
 

--- a/secimport/cli.py
+++ b/secimport/cli.py
@@ -196,11 +196,23 @@ class SecImportCLI:
             encoding="utf-8",
         )
         if with_dtrace.strip() != "1":
-            colored_print(
-                COLORS.FAIL,
-                f"\nIt seems that {python_interpreter} was compiled without --with-dtrace=1. "
-                "secimport will probably not work properly!\n",
-            )
+            import importlib.util
+            if importlib.util.find_spec("stapsdt") is not None:
+                colored_print(
+                    COLORS.OKBLUE,
+                    f"\n[!] {python_interpreter} was compiled without --with-dtrace=1.\n"
+                    "However, 'stapsdt' is installed. secimport will use dynamic USDT probes.\n"
+                    "Note: Ensure that the 'libstapsdt' system library is also installed (https://github.com/linux-usdt/libstapsdt).\n",
+                )
+            else:
+                colored_print(
+                    COLORS.FAIL,
+                    f"\nIt seems that {python_interpreter} was compiled without --with-dtrace=1. "
+                    "secimport will probably not work properly!\n"
+                    "To enable dynamic USDT probes on standard python binaries, please:\n"
+                    "1. Install 'libstapsdt' system library: https://github.com/linux-usdt/libstapsdt\n"
+                    "2. Install 'stapsdt' python package: pip install stapsdt\n",
+                )
 
         if entrypoint:
             entrypoint_cmd = f'bash -c "{python_interpreter} {entrypoint}"'

--- a/secimport/sandbox_helper.py
+++ b/secimport/sandbox_helper.py
@@ -4,8 +4,40 @@ Import python modules with syscalls supervision.
 Copyright (c) 2022 Avi Lumelsky
 """
 
+import importlib.util
+import sysconfig
 from secimport.backends.common.instrumentation_backend import InstrumentationBackend
 from secimport.backends.common.utils import DEFAULT_BACKEND
+
+# Check if the python interpreter was built with DTrace support (static USDT)
+HAS_STATIC_DTRACE = sysconfig.get_config_var("WITH_DTRACE") == 1
+
+# Optional: stapsdt for dynamic USDT probes as a fallback
+STAPSDT_AVAILABLE = importlib.util.find_spec("stapsdt") is not None
+
+# Global singletons to prevent resource leakage
+_GLOBAL_STAPS_PROVIDER = None
+_GLOBAL_ENTRY_PROBE = None
+
+
+def _get_staps_probe():
+    """Returns a singleton USDT probe if static DTrace is missing and stapsdt is available."""
+    global _GLOBAL_STAPS_PROVIDER, _GLOBAL_ENTRY_PROBE
+
+    # Only use stapsdt if static DTrace is NOT supported by the interpreter
+    if not HAS_STATIC_DTRACE and STAPSDT_AVAILABLE and _GLOBAL_STAPS_PROVIDER is None:
+        import stapsdt
+
+        # To follow the principle of minimum change, we use the standard "python" provider name.
+        # This makes the dynamic probe a drop-in replacement for the missing static probe.
+        _GLOBAL_STAPS_PROVIDER = stapsdt.Provider("python")
+
+        # We also use the standard "function__entry" probe name that secimport already expects.
+        _GLOBAL_ENTRY_PROBE = _GLOBAL_STAPS_PROVIDER.add_probe(
+            "function__entry", stapsdt.ArgTypes.uint64
+        )
+        _GLOBAL_STAPS_PROVIDER.load()
+    return _GLOBAL_ENTRY_PROBE
 
 
 def secure_import(
@@ -33,15 +65,19 @@ def secure_import(
         log_file_system (bool, optional): Whether to log filesystem calls - e.g read, open, write, etc.
         destructive (bool, optional): Whether to kill the process with -9 sigkill upon violation of any of the configurations above.
     Returns:
-        _type_: A Python Module. The module is supervised by a dtrace process with destructive capabilities unless the 'destructive' argument is set to False.
+        _type_: A Python Module. The module is supervised by the selected instrumentation backend (dtrace/ebpf) with destructive capabilities unless the 'destructive' argument is set to False.
     """
+
+    # Get the dynamic probe (will only be initialized if static DTrace is missing)
+    _entry_probe = _get_staps_probe()
 
     if backend == InstrumentationBackend.EBPF:
         from secimport.backends.bpftrace_backend.bpftrace_backend import (
             run_bpftrace_script_for_module,
         )
 
-        assert run_bpftrace_script_for_module(
+        # Replaced assert with explicit check to prevent bypassing security when python is run with optimization (-O)
+        if not run_bpftrace_script_for_module(
             module_name=module_name,
             allow_shells=allow_shells,
             allow_networking=allow_networking,
@@ -51,13 +87,17 @@ def secure_import(
             log_network=log_network,
             log_file_system=log_file_system,
             destructive=destructive,
-        )
+        ):
+            raise RuntimeError(
+                f"Failed to start eBPF instrumentation for module '{module_name}'"
+            )
     elif backend == InstrumentationBackend.DTRACE:
         from secimport.backends.dtrace_backend.dtrace_backend import (
             run_dtrace_script_for_module,
         )
 
-        assert run_dtrace_script_for_module(
+        # Replaced assert with explicit check to ensure the instrumentation is active before importing
+        if not run_dtrace_script_for_module(
             module_name=module_name,
             allow_shells=allow_shells,
             allow_networking=allow_networking,
@@ -67,9 +107,16 @@ def secure_import(
             log_network=log_network,
             log_file_system=log_file_system,
             destructive=destructive,
-        )
+        ):
+            raise RuntimeError(
+                f"Failed to start DTrace instrumentation for module '{module_name}'"
+            )
     else:
         raise NotImplementedError(f"backend '{backend}' is not implemented.")
+
+    # Fire the dynamic probe before import (if applicable)
+    if _entry_probe:
+        _entry_probe.fire(module_name)
 
     _module = __import__(module_name, **kwargs)
     return _module

--- a/tests/test_stapsdt_support.py
+++ b/tests/test_stapsdt_support.py
@@ -1,0 +1,79 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import importlib.util
+from secimport.sandbox_helper import secure_import
+from secimport.backends.common.instrumentation_backend import InstrumentationBackend
+
+# Check if stapsdt is available for testing
+STAPSDT_AVAILABLE = importlib.util.find_spec("stapsdt") is not None
+
+
+class TestStapsdtSupport(unittest.TestCase):
+    def setUp(self):
+        # Clear global singleton state before each test to ensure isolation
+        import secimport.sandbox_helper
+
+        secimport.sandbox_helper._GLOBAL_STAPS_PROVIDER = None
+        secimport.sandbox_helper._GLOBAL_ENTRY_PROBE = None
+
+    @unittest.skipIf(not STAPSDT_AVAILABLE, "stapsdt package not installed")
+    @patch("stapsdt.Provider")
+    @patch(
+        "secimport.backends.bpftrace_backend.bpftrace_backend.run_bpftrace_script_for_module"
+    )
+    def test_secure_import_with_stapsdt_fires_probe_when_static_dtrace_missing(
+        self, mock_run_bpftrace, mock_provider_class
+    ):
+        """Verify stapsdt fires when static DTrace is missing."""
+        import stapsdt
+        mock_provider = MagicMock()
+        mock_probe = MagicMock()
+        mock_provider_class.return_value = mock_provider
+        mock_provider.add_probe.return_value = mock_probe
+        mock_run_bpftrace.return_value = True
+
+        # Simulate static DTrace MISSING
+        with patch("secimport.sandbox_helper.HAS_STATIC_DTRACE", False):
+            secure_import("math", backend=InstrumentationBackend.EBPF)
+
+            # Verify stapsdt WAS used with the standard "python" provider and "function__entry" probe
+            mock_provider_class.assert_called_with("python")
+            mock_provider.add_probe.assert_called_with("function__entry", stapsdt.ArgTypes.uint64)
+            mock_provider.load.assert_called_once()
+            mock_probe.fire.assert_called_once_with("math")
+
+    @unittest.skipIf(not STAPSDT_AVAILABLE, "stapsdt package not installed")
+    @patch("stapsdt.Provider")
+    @patch(
+        "secimport.backends.bpftrace_backend.bpftrace_backend.run_bpftrace_script_for_module"
+    )
+    def test_secure_import_skips_stapsdt_when_static_dtrace_exists(
+        self, mock_run_bpftrace, mock_provider_class
+    ):
+        """Verify stapsdt is NOT used when static DTrace exists."""
+        mock_run_bpftrace.return_value = True
+
+        # Simulate static DTrace EXISTS
+        with patch("secimport.sandbox_helper.HAS_STATIC_DTRACE", True):
+            secure_import("math", backend=InstrumentationBackend.EBPF)
+
+            # Verify stapsdt was NOT used
+            mock_provider_class.assert_not_called()
+
+    @patch("importlib.util.find_spec")
+    def test_stapsdt_not_available_does_not_fail(self, mock_find_spec):
+        # Simulate stapsdt not being installed
+        mock_find_spec.return_value = None
+
+        with patch("secimport.sandbox_helper.STAPSDT_AVAILABLE", False):
+            with patch(
+                "secimport.backends.bpftrace_backend.bpftrace_backend.run_bpftrace_script_for_module"
+            ) as mock_run:
+                mock_run.return_value = True
+                module = secure_import("math", backend=InstrumentationBackend.EBPF)
+                self.assertIsNotNone(module)
+                self.assertEqual(module.__name__, "math")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Dynamic USDT Support via stapsdt and Security Hardening

Enhanced secimport with dynamic USDT support for standard Python and hardened security against optimized mode bypasses.

## Key Technical Changes

 - Dynamic USDT Support: Integrated stapsdt to support standard Python binaries without DTrace, using a singleton pattern
   for the provider to prevent resource leaks.
 - CLI Enhancements: Added detection for WITH_DTRACE and provided detailed installation guides for libstapsdt and stapsdt.

## changes
- [x] Implement dynamic USDT probe firing in `secure_import` using `stapsdt` to support standard Python binaries without DTrace.
- [x] Replace `assert` with explicit `RuntimeError` in `sandbox_helper.py` 
- [x] Update CLI to detect `WITH_DTRACE` and provide installation guides for `libstapsdt` and `stapsdt`.
- [ ] ~Add `tests/test_stapsdt_support.py`~ (excluded)
- [ ] ~support uv / add PEP 621 [project] to pyproject.toml~ (excluded)

## References
- https://github.com/sthima/libstapsdt
- https://github.com/linux-usdt/python-stapsdt

## Note
I used the Gemini CLI to help with the specific implementation details and drafting this PR description.

See also: https://github.com/linux-usdt/libstapsdt/pull/34

as expected, normal trace.bt will not work.
```
$ sudo secimport/profiles/trace.bt -c .venv/bin/python3 -o trace0.log .venv/bin/python3
ERROR: couldn't get argument 0 for .venv/bin/python3::function__entry
```

so I just added some more commits to address this issue.

## remain issues

- [ ] need to add `missing_probes config` to work with libstapsdt
```diff
diff --git a/secimport/profiles/trace.bt b/secimport/profiles/trace.bt
index 9609ce9..0535b82 100755
--- a/secimport/profiles/trace.bt
+++ b/secimport/profiles/trace.bt
@@ -1,5 +1,9 @@
 #!/usr/bin/env bpftrace

+config = {
+  missing_probes = "ignore";
+}
+
 // A profiling script that logs all the syscalls, per python module.
 // It can be attached to a running process using -p or can be used to trace a python shell interactively.
 //
```

- [ ] the bpftrace works just fine but older version emits some error under arm64. so I prepend `bpftrace` command like as `./bpftrace` to use local bpftrace version. (we might needs some `os.getenv("BPFTRACE_BIN", "bpftrace")` or somthing.

